### PR TITLE
WIP: Add sticky ToC for blog posts, #24

### DIFF
--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,0 +1,28 @@
+/* Table of Contents */
+/* source: https://ma.ttias.be/adding-a-sticky-table-of-contents-in-hugo-to-posts/#styling-the-table-of-contents */
+/* similar: from: https://www.bram.us/2020/01/10/smooth-scrolling-sticky-scrollspy-navigation/ */
+
+window.addEventListener('DOMContentLoaded', () => {
+  const tocObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      const id = entry.target.getAttribute('id');
+      if (entry.intersectionRatio > 0) {
+        clearActiveStates();
+        //document.querySelector(`aside nav li a[href="#${id}"]`).parentElement.classList.add('active');
+        document.querySelector(`aside div nav li a[href="#${id}"]`).parentElement.classList.add('active');}
+    });
+  });
+
+  // track all headings that have an `id` applied
+  document.querySelectorAll('h1[id],h2[id],h3[id],h4[id]').forEach((section) => {
+    tocObserver.observe(section);
+  });
+});
+
+function clearActiveStates() {
+  //document.querySelectorAll('aside nav li').forEach((section) => {
+  //section.classList.remove('active');
+  document.querySelectorAll('aside div nav li a').forEach((section) => {
+    section.parentElement.classList.remove('active');
+  });
+}

--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -466,12 +466,13 @@ article footer a.btn-links {
   }
 }
 
-// Series + collections table of contents
+// Series, collections, and blog posts table of contents
 
 details#PageTableOfContents nav#TableOfContents ul li:hover {
   @extend .bg-#{$siteBgColor};
 }
 
+nav#TableOfContents ul li,
 nav#SectionTableOfContents ul li,
 nav#SeriesTableOfContents ul li {
   @extend .pl2, .bl, .bw1, .b--transparent;

--- a/layouts/blog/single-sidebar.html
+++ b/layouts/blog/single-sidebar.html
@@ -24,5 +24,6 @@
   {{ partial "shared/sidebar-scaffold.html" . }}
   {{ .Scratch.Set "details" "open" }}
   {{ partial "shared/post-details.html" . }}
+  {{ partial "shared/post-toc.html" . }}
 </aside>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,4 +16,7 @@
   <!-- headroom.js -->
   {{ $mainJs := resources.Get "js/main.js" | js.Build "main.js" | minify | fingerprint }}
   <script src="{{ $mainJs.RelPermalink }}" type="text/javascript"></script>
+  <!-- toc.js -->
+  {{ $tocJs := resources.Get "js/toc.js" | js.Build "toc.js" | minify | fingerprint }}
+  <script src="{{ $tocJs.RelPermalink }}" type="text/javascript"></script>
 </head>

--- a/layouts/partials/shared/post-toc.html
+++ b/layouts/partials/shared/post-toc.html
@@ -1,0 +1,6 @@
+<!--SPC: adapted from layouts/partials/shared/series-sidebar.html-->
+{{ $page_toc_label := .Params.sidebar.text_contents_label | default "On this page" }}
+<div class="sticky ph4 pb4">
+    <h2 class="mv0 f5 fw7 ttu tracked dib">{{ $page_toc_label }}</h2>
+    {{ .TableOfContents }}
+</div>


### PR DESCRIPTION
Adds:
- scrollspy JavaScript to make a responsive ToC (inserted into **head.html**)
- **blog-toc.html** partial for a basic ToC layout
- **blog-toc partial** to single-sidebar layout for blog posts

Modifies:
- **scaffold.scss** to extend styling to nav#TableOfContents

Known bugs:
- Existing `.sticky` class in **scaffold.scss** does not leave enough room for headroom for the blog ToC. Possible solutions:
  - Modify `.sticky` tachyon property to `.top-2-l`, this approach might create extra unwanted space elsewhere the .sticky class is used
  - Create a new class `.sticky-toc` (or something) that uses tachyon `.top-2-l`, this approach [does not reuse existing code](https://github.com/hugo-apero/hugo-apero/issues/24#issuecomment-843405405)
- May interfere with styling for SectionTableOfContents
- JavaScript observer is not optimal for views with multiple headings/targets as mentioned in issue #24 

😊 @apreshill this seems silly to ask but what is your workflow for testing changes to this repo to see how the site will render, since the repo is not an actual website? Do you first test the changes directly in a different website's **theme/hugo-apero** folder and then port over to this repo when you're done? I was scratching my head trying to figure out a good way to test changes to **scaffold.scss** where there are references to site colors that aren't recognized if I try using them in **assets/custom.scss** (e.g. `.bg-#{$siteBgColor}`)