### PR TITLE
Add option to place a border around avatar image for ✨emphasis✨

### DIFF
--- a/exampleSite/content/about/sidebar/index.md
+++ b/exampleSite/content/about/sidebar/index.md
@@ -3,6 +3,7 @@
 author: "Hugo Apéro"
 role: "A Hugo theme"
 avatar_shape: rounded # circle, square, rounded, leave blank to exclude
+avatar_border: true # should a border be placed on avatar, true or false
 show_social_links: true # specify social accounts in site config
 audio_link_label: "How to say my name" # leave blank to exclude
 link_list_label: "Interests" # bookmarks, elsewhere, etc.

--- a/layouts/about/list.html
+++ b/layouts/about/list.html
@@ -53,8 +53,9 @@
             {{ if .Params.avatar_shape }}
               {{- $avatar := ($sidebar_pg.Resources.ByType "image").GetMatch "*avatar*" -}}
               {{ $avatar_shape := .Params.avatar_shape | default "circle" }}
+              {{ $avatar_border := .Params.avatar_border }}
               {{ with $avatar }}
-                <img src="{{ .RelPermalink }}" class="h4 w4 dib {{if eq $avatar_shape "rounded"}}br3{{end}}{{if eq $avatar_shape "circle"}}br-100{{end}}" alt="avatar">
+                <img src="{{ .RelPermalink }}" class="h4 w4 dib {{if eq $avatar_shape "rounded"}}br3{{end}}{{if eq $avatar_shape "circle"}}br-100{{end}} {{ if $avatar_border }} ba bw1 {{end}}" alt="avatar">
               {{ end }}
             {{ end }}
             <h2 class="f-subheadline f4-ns fw6">{{ .Params.author }}</h2>


### PR DESCRIPTION
Hi! I'm putting some final touches on my site (converted from the Academic theme) and it's been such an easy switch. Thank you for creating such an amazing theme! 

I decided to add a little border around my avatar image and thought I would try my hand at integrating it with Hugo templates. I'm not sure if this could be done more succinctly, but thought others may want this feature, too. You can see what it looks like [here](https://jdtrat.com/about/). 