### PR TITLE
add mathjax rendering

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -76,6 +76,10 @@ enableEmoji = true
     theme = "boxy-light"
     label = "comments :crystal_ball:"
 
+  # Configuration of math rendering
+  [params.math]
+    renderer = "mathjax" # currently only "mathjax", might include "katex" in the future
+
   # Social icons may appear on homepage and in site header or footer
   # Configure show/hide above - add as many as you like below
   # Icon pack "fab" includes brand icons, see: https://fontawesome.com/icons?d=gallery&s=brands&m=free

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -78,7 +78,7 @@ enableEmoji = true
 
   # Configuration of math rendering
   [params.math]
-    renderer = "mathjax" # currently only "mathjax", might include "katex" in the future
+    renderer = "katex" # one of "mathjax" / "katex" 
 
   # Social icons may appear on homepage and in site header or footer
   # Configure show/hide above - add as many as you like below

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -14,7 +14,7 @@ categories:
 ## Rendering mathematical equations
 
 Examples from the [mathjax demo](https://www.mathjax.org/#demo).
-But thy work with `katex` as well.
+But they work with `katex` as well.
 
 ### Rmarkdown
 

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -13,17 +13,49 @@ categories:
 
 ## Rendering mathematical equations
 
-Example from the [mathjax demo](https://www.mathjax.org/#demo):
+Examples from the [mathjax demo](https://www.mathjax.org/#demo):
 
-When $a \ne 0$, there are two solutions to \(ax^2 + bx + c = 0\) and they are
+### Rmarkdown
+
+In `.Rmarkdown` documents, you can use either
+
+```
+$a \ne 0$
+```
+
+to get inline math: `\(a \ne 0\)`.
+There is no conflict with using dollar symbols regularly, because `knitr` automatically escapes freestanding dollar symbols.
+
+And you can use
+
+```
+$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+```
+
+to get a math paragraph:
+
 $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 
-If this markdown file where created by knitr, it would look like this:
+### md
 
-Example from the [mathjax demo](https://www.mathjax.org/#demo):
+In `.md` documents, you can **not** use the single dollar syntax.
+The double dollar syntax still gives you a math paragraph.
 
-When `\(a \ne 0\)`, there are two solutions to (ax^2 + bx + c = 0) and they are
-`$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$`
+```
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+```
+
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}$$
+
+In order to get inline equations, use:
+
+```
+`\(a \ne 0\)`
+or
+\\(a \ne 0\\)
+```
+
+to get: `\(a \ne 0\)`.
 
 
 

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -13,10 +13,11 @@ categories:
 
 ## Rendering mathematical equations
 
-Example from the [mathjax demo](https://www.mathjax.org/#demo)
+Example from the [mathjax demo](https://www.mathjax.org/#demo):
 
 When $a \ne 0$, there are two solutions to \(ax^2 + bx + c = 0\) and they are
 $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+
 
 
 

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -11,3 +11,13 @@ categories:
 - evergreen
 ---
 
+## Rendering mathematical equations
+
+Example from the [mathjax demo](https://www.mathjax.org/#demo)
+
+When $a \ne 0$, there are two solutions to \(ax^2 + bx + c = 0\) and they are
+$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
+
+
+
+

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -13,7 +13,8 @@ categories:
 
 ## Rendering mathematical equations
 
-Examples from the [mathjax demo](https://www.mathjax.org/#demo):
+Examples from the [mathjax demo](https://www.mathjax.org/#demo).
+But thy work with `katex` as well.
 
 ### Rmarkdown
 

--- a/exampleSite/content/blog/evergreen/index.md
+++ b/exampleSite/content/blog/evergreen/index.md
@@ -18,7 +18,12 @@ Example from the [mathjax demo](https://www.mathjax.org/#demo):
 When $a \ne 0$, there are two solutions to \(ax^2 + bx + c = 0\) and they are
 $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 
+If this markdown file where created by knitr, it would look like this:
 
+Example from the [mathjax demo](https://www.mathjax.org/#demo):
+
+When `\(a \ne 0\)`, there are two solutions to (ax^2 + bx + c = 0) and they are
+`$$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$`
 
 
 

--- a/exampleSite/content/contributors.md
+++ b/exampleSite/content/contributors.md
@@ -22,4 +22,6 @@ Thank you to all the folks who have contributed both technical and creative skil
 
 + [Athanasia Monika Mowinckel :purple_heart:](https://drmowinckels.io/) (for help finding :bug: and SASS support for making color themes work so much better :art:)
 
++ [Jannik Buhr :otter:](https://jmbuhr.de) (enabling math rendering with mathjax and katex)
+
 And last but not least, Eric Anderson and the team at [Formspree](https://formspree.io/) for developing a Hugo theme with such great bones: <https://github.com/formspree/blogophonic-hugo>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,9 +21,8 @@
   {{ with site.Params.math }}
   {{ with .renderer }}
     {{ if eq . "mathjax" }}
-    <script>console.log("{{.}}")</script>
-    <script src="//yihui.org/js/math-code.js" type="text/javascript"></script>
-    <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     {{ end }}
   {{ end }}
   {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,29 +21,7 @@
   {{ with site.Params.math }}
   {{ with .renderer }}
     {{ if eq . "mathjax" }}
-    <script>
-      // from: https://yihui.org/js/math-code.js
-        var i, text, code, codes = document.getElementsByTagName('code');
-        for (let i = 0; i < codes.length;) {
-          code = codes[i];
-          if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
-            text = code.textContent;
-            if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
-              text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
-              code.textContent = text;
-            }
-            if (/^\\\((.|\s)+\\\)$/.test(text) ||
-                /^\\\[(.|\s)+\\\]$/.test(text) ||
-                /^\$(.|\s)+\$$/.test(text) ||
-                /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
-              code.outerHTML = code.innerHTML;  // remove <code></code>
-              continue;
-            }
-          }
-          i++;
-        }
-    </script>
-    <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    {{ partial "shared/math-render-mathjax.html" }}
     {{ end }}
   {{ end }}
   {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,8 +21,29 @@
   {{ with site.Params.math }}
   {{ with .renderer }}
     {{ if eq . "mathjax" }}
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script>
+      // from: https://yihui.org/js/math-code.js
+        var i, text, code, codes = document.getElementsByTagName('code');
+        for (let i = 0; i < codes.length;) {
+          code = codes[i];
+          if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
+            text = code.textContent;
+            if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
+              text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
+              code.textContent = text;
+            }
+            if (/^\\\((.|\s)+\\\)$/.test(text) ||
+                /^\\\[(.|\s)+\\\]$/.test(text) ||
+                /^\$(.|\s)+\$$/.test(text) ||
+                /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
+              code.outerHTML = code.innerHTML;  // remove <code></code>
+              continue;
+            }
+          }
+          i++;
+        }
+    </script>
+    <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     {{ end }}
   {{ end }}
   {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -19,9 +19,13 @@
     </div>
   </nav>
   {{ with site.Params.math }}
+    {{ partial "shared/math-render-katex.html" }}
   {{ with .renderer }}
     {{ if eq . "mathjax" }}
     {{ partial "shared/math-render-mathjax.html" }}
+    {{ end }}
+    {{ if eq . "katex" }}
+    {{ partial "shared/math-render-katex.html" }}
     {{ end }}
   {{ end }}
   {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,4 +18,13 @@
       {{ end }}
     </div>
   </nav>
+  {{ with site.Params.math }}
+  {{ with .renderer }}
+    {{ if eq . "mathjax" }}
+    <script>console.log("{{.}}")</script>
+    <script src="//yihui.org/js/math-code.js" type="text/javascript"></script>
+    <script async src="//mathjax.rstudio.com/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    {{ end }}
+  {{ end }}
+  {{ end }}
 </footer>

--- a/layouts/partials/shared/math-preprocess.html
+++ b/layouts/partials/shared/math-preprocess.html
@@ -1,0 +1,22 @@
+<script>
+// from: https://yihui.org/js/math-code.js
+    var i, text, code, codes = document.getElementsByTagName('code');
+    for (let i = 0; i < codes.length;) {
+      code = codes[i];
+      if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
+        text = code.textContent;
+        if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
+          text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
+          code.textContent = text;
+        }
+        if (/^\\\((.|\s)+\\\)$/.test(text) ||
+            /^\\\[(.|\s)+\\\]$/.test(text) ||
+            /^\$(.|\s)+\$$/.test(text) ||
+            /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
+          code.outerHTML = code.innerHTML;  // remove <code></code>
+          continue;
+        }
+      }
+      i++;
+    }
+</script>

--- a/layouts/partials/shared/math-render-katex.html
+++ b/layouts/partials/shared/math-render-katex.html
@@ -1,0 +1,16 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css" integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js" integrity="sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/contrib/auto-render.min.js" integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl" crossorigin="anonymous"></script>
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+      renderMathInElement(document.body, {
+        delimiters: [
+            {left: '$$', right: '$$', display: true},
+            {left: '\\(', right: '\\)', display: false}
+        ],
+        ignoredTags: ["script", "noscript", "style", "textarea", "option", "pre"],
+        throwOnError: false
+      });
+  });
+</script>
+

--- a/layouts/partials/shared/math-render-mathjax.html
+++ b/layouts/partials/shared/math-render-mathjax.html
@@ -1,0 +1,34 @@
+<script type="text/javascript">
+  // from: https://yihui.org/js/math-code.js
+  var i, text, code, codes = document.getElementsByTagName('code');
+  for (let i = 0; i < codes.length;) {
+    code = codes[i];
+    if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
+      text = code.textContent;
+      if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
+        text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
+        code.textContent = text;
+      }
+      if (/^\\\((.|\s)+\\\)$/.test(text) ||
+          /^\\\[(.|\s)+\\\]$/.test(text) ||
+          /^\$(.|\s)+\$$/.test(text) ||
+          /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
+        code.outerHTML = code.innerHTML;  // remove <code></code>
+        continue;
+      }
+      }
+    i++;
+    }
+</script>
+<script type="text/javascript">
+  MathJax = {
+    tex: {
+      inlineMath: [['\\(', '\\)']]
+    }
+  };
+</script>
+<script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+
+
+

--- a/layouts/partials/shared/math-render-mathjax.html
+++ b/layouts/partials/shared/math-render-mathjax.html
@@ -1,26 +1,4 @@
 <script type="text/javascript">
-  // from: https://yihui.org/js/math-code.js
-  var i, text, code, codes = document.getElementsByTagName('code');
-  for (let i = 0; i < codes.length;) {
-    code = codes[i];
-    if (code.parentNode.tagName !== 'PRE' && code.childElementCount === 0) {
-      text = code.textContent;
-      if (/^\$[^$]/.test(text) && /[^$]\$$/.test(text)) {
-        text = text.replace(/^\$/, '\\(').replace(/\$$/, '\\)');
-        code.textContent = text;
-      }
-      if (/^\\\((.|\s)+\\\)$/.test(text) ||
-          /^\\\[(.|\s)+\\\]$/.test(text) ||
-          /^\$(.|\s)+\$$/.test(text) ||
-          /^\\begin\{([^}]+)\}(.|\s)+\\end\{[^}]+\}$/.test(text)) {
-        code.outerHTML = code.innerHTML;  // remove <code></code>
-        continue;
-      }
-      }
-    i++;
-    }
-</script>
-<script type="text/javascript">
   MathJax = {
     tex: {
       inlineMath: [['\\(', '\\)']]


### PR DESCRIPTION
Hi there,
I saw the discussion in https://github.com/hugo-apero/hugo-apero/issues/38 and turned it into a PR. Initially I also wanted to support [katex](https://katex.org/) for improved performance but haven't been able to get it to work. Apparently `rmarkdown::render` of `Rmarkdown` files adds backticks around dollar expressions in the `.markdown` file, which then get turned into `<code>` blocks. [Mathjax](https://www.mathjax.org/) handles those just fine, but katex keeps them, leading to artifacts.

This is why I kept the toml/yaml options extensible with a `params.math.renderer` option instead of just a mathjax option.