### PR TITLE
Fixed issue #57 — Hugo 0.80.0 installation fails

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -6,7 +6,8 @@ local({
   # use theme in root
   options(blogdown.themesDir = '../..')
   # pin hugo version
-  options(blogdown.hugo.version = "0.80.0")
+  ## stop pinning as Hugo 0.80.0 installation fails. See issue #57 (https://github.com/hugo-apero/hugo-apero/issues/57)
+  ### options(blogdown.hugo.version = "0.80.0")
   # full markdown mode
   options(blogdown.method = "markdown")
 })

--- a/.Rprofile
+++ b/.Rprofile
@@ -6,8 +6,8 @@ local({
   # use theme in root
   options(blogdown.themesDir = '../..')
   # pin hugo version
-  ## stop pinning as Hugo 0.80.0 installation fails. See issue #57 (https://github.com/hugo-apero/hugo-apero/issues/57)
-  ### options(blogdown.hugo.version = "0.80.0")
+  ## updating the pinned Hugo version to 0.89.2. See issue #57 (https://github.com/hugo-apero/hugo-apero/issues/57)
+  options(blogdown.hugo.version = "0.89.2")
   # full markdown mode
   options(blogdown.method = "markdown")
 })


### PR DESCRIPTION
Fix was simple. Avoid pinning the Hugo version to 0.80.0 and use the latest version.