### PR TITLE
Add YAML option for showing/hiding link buttons on listing pages

### DIFF
--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -8,6 +8,7 @@ show_post_thumbnail: true
 thumbnail_left: true # for list-sidebar only
 show_author_byline: true
 show_post_date: true
+show_button_links: false
 # for listing page layout
 layout: list-sidebar # list, list-sidebar, list-grid
 

--- a/exampleSite/content/project/_index.md
+++ b/exampleSite/content/project/_index.md
@@ -5,6 +5,7 @@ author: "The R Markdown Team @RStudio"
 show_post_thumbnail: true
 show_author_byline: true
 show_post_date: false
+show_button_links: false
 # for listing page layout
 layout: list-grid # list, list-sidebar, list-grid
 

--- a/exampleSite/content/talk/_index.md
+++ b/exampleSite/content/talk/_index.md
@@ -7,6 +7,7 @@ show_post_thumbnail: true
 show_author_byline: true
 show_post_date: true
 show_post_time: true
+show_button_links: true
 # for listing page layout
 layout: list # list, list-sidebar
 

--- a/layouts/partials/shared/summary-compact.html
+++ b/layouts/partials/shared/summary-compact.html
@@ -51,7 +51,7 @@
       {{ if .Params.show_author_byline }}
         <p class="f7 dib mv1">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>
       {{ end }}
-      {{ if .Params.links }}
+      {{ if and $root.Params.show_button_links .Params.links }}
         <p class="db pt1">
         {{ partial "shared/btn-links.html" . }}
         </p>
@@ -84,7 +84,11 @@
       {{ if $root.Params.show_author_byline }}
         <p class="f7 dib mv1">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>
       {{ end }}
+      {{ if and $root.Params.show_button_links .Params.links }}
+        <p class="db pt1">
+        {{ partial "shared/btn-links.html" . }}
+        </p>
+      {{ end }}
     </footer>
   {{ end }}
-
 </article>

--- a/layouts/partials/shared/summary-grid.html
+++ b/layouts/partials/shared/summary-grid.html
@@ -18,14 +18,23 @@
   </div>
   {{ end }}
   <div class="ph0 pa2-m pa3-l">
-    <h1 class="f3 f4-l mv2 lh-title fw4"><a href="{{ .RelPermalink }}" class="db">{{ .Title | markdownify }}</a></h1>
-    {{ range first 1 (.GetTerms "series") }}
-      <h2 class="f5"><i class="fas fa-stream fa-fw pr1"></i><small class="f5 ttu tracked">Series: </small><a class="link i dim" href="{{ $section.RelPermalink }}">{{ .LinkTitle }}</a></h2>
-    {{ end }}
+    <header>
+      <h1 class="f3 f4-l mv2 lh-title fw4"><a href="{{ .RelPermalink }}" class="db">{{ .Title | markdownify }}</a></h1>
+      {{ range first 1 (.GetTerms "series") }}
+        <h2 class="f5"><i class="fas fa-stream fa-fw pr1"></i><small class="f5 ttu tracked">Series: </small><a class="link i dim" href="{{ $section.RelPermalink }}">{{ .LinkTitle }}</a></h2>
+      {{ end }}
+    </header>
       {{ $summary := cond (ne .Params.excerpt nil) .Params.excerpt .Summary }}
       {{ with $summary }}<p class="f6 lh-copy">{{ . | markdownify | emojify }}</p>{{ end }}
     <!--ensures section Params are respected-->
-    {{ if $root.Params.show_author_byline }}<p class="f7 db mv1">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>{{ end }}
-    {{ if $root.Params.show_post_date }}<p class="f7 db mv1">{{ .PublishDate.Format "January 2, 2006" }}</p>{{ end }}
+    <footer>
+      {{ if $root.Params.show_author_byline }}<p class="f7 db mv1">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>{{ end }}
+      {{ if $root.Params.show_post_date }}<p class="f7 db mv1">{{ .PublishDate.Format "January 2, 2006" }}</p>{{ end }}
+      {{ if and $root.Params.show_button_links .Params.links }}
+          <p class="db pt1">
+          {{ partial "shared/btn-links.html" . }}
+          </p>
+      {{ end }}
+    </footer>
   </div>
 </article>

--- a/layouts/partials/shared/summary.html
+++ b/layouts/partials/shared/summary.html
@@ -2,7 +2,7 @@
 {{ $section := $page.CurrentSection }}     <!--save branch section-->
 {{ $root := .Scratch.Get "$root" }}     <!--save root section-->
 <article class="mv4 mv5-l bb">
-  
+
   <!--if show_post_thumbnail is TRUE in root-->
   {{ if $root.Params.show_post_thumbnail }}
   <!--featured image for the leaf bundle-->
@@ -34,10 +34,15 @@
       <!--ensures section Params are respected-->
       {{ if $root.Params.show_author_byline }}<p class="f7 db mv1">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>{{ end }}
       {{ if $root.Params.show_post_date }}<p class="f7 db mv1">{{ .PublishDate.Format "January 2, 2006" }}</p>{{ end }}
+      {{ if and $root.Params.show_button_links .Params.links }}
+        <p class="db pt1">
+        {{ partial "shared/btn-links.html" . }}
+        </p>
+      {{ end }}
     </footer>
     </div>
   </div>
-  
+
   <!--if show_post_thumbnail is FALSE in root-->
   {{ else }}
   <div class="measure-wide center mb4 mb5-l">
@@ -52,6 +57,11 @@
     <footer>
       {{ if $root.Params.show_author_byline }}<p class="f7 db mv2">{{ if .Params.author }}By {{ .Params.author }}{{ end }}{{ with .Params.categories }} in{{ range . }} <a href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a> {{ end }}{{ end }}</p>{{ end }}
       {{ if $root.Params.show_post_date }}<p class="f7 db mv2">{{ .PublishDate.Format "January 2, 2006" }}</p>{{ end }}
+      {{ if and $root.Params.show_button_links .Params.links }}
+        <p class="db pt1">
+        {{ partial "shared/btn-links.html" . }}
+        </p>
+      {{ end }}
     </footer>
   </div>
   {{ end }}


### PR DESCRIPTION
This PR adds a YAML option for showing/hiding link buttons on listing pages. This gives users a little more flexibility in how they style their website.

It also addresses some former inconsistencies in when link buttons were shown. For example, Talk listings would only show link buttons when `show_post_thumbnail` was set to `true`.  Now the buttons can be shown (or hidden) regardless of what other YAML options have been chosen.