### PR TITLE
Fix About sidebar appearance on small screens

### DIFF
--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -409,7 +409,6 @@ details#PageTableOfContents {
 
 .about-sidebar {
   @extend .self-start, .sticky, .bg-#{$sidebarBgColor}, .#{$sidebarTextColor};
-  height: 100vh;
 }
 .about-sidebar a:not(.link) {
   @extend .#{$sidebarLinkColor};


### PR DESCRIPTION
The sidebar on the About page spills outside of the background and into the next section on small screens currently. This picture shows an example from the RStudio viewer, but I've noticed this browsing other Apero sites on my iPhone too (e.g., the documentation site, I sent some pictures on the discord too).

![Screen Shot 2021-11-20 at 9 20 05 PM](https://user-images.githubusercontent.com/51542091/142749544-ddf1c0d9-65ff-4a2e-aa18-4170b8b85c36.png)

This is caused by the `height: 100vh;` property of the `.about-sidebar`. If you remove it the sidebar is fixed on small screens. This also doesn't affect the appearance on not small screens in any noticeable way as far as I could tell. Here's a picture of how it looks after the fix in the RStudio viewer.

![Screen Shot 2021-11-20 at 9 20 22 PM](https://user-images.githubusercontent.com/51542091/142749548-00e76f92-ebca-43f4-acd5-e6751312b698.png)
s