### PR TITLE
Make about link list URLs context sensitive

### DIFF
--- a/layouts/about/list.html
+++ b/layouts/about/list.html
@@ -81,11 +81,7 @@
           <div class="pa1 pa2-ns tc ph4">
             <h5 class="f-subheadline f4 fw2 ttu tracked">{{ .Params.link_list_label }}</h5>
             <ul class="list measure center ph4 pb4">
-            {{ range .Params.link_list }}
-              <li class="lh-copy pv2 ba bl-0 bt-0 br-0 b--dotted b--black-20">
-                <a href="{{ .url }}" target="_blank">{{ .name }}</a>
-              </li>
-            {{ end }}
+              {{ partial "shared/about-links" . }}
             </ul>
           </div>
         </sidebar>

--- a/layouts/partials/shared/about-links.html
+++ b/layouts/partials/shared/about-links.html
@@ -1,0 +1,13 @@
+{{ range .Params.link_list }}
+  {{ $link := .url }}
+  {{ $scheme := (urls.Parse $link).Scheme }}
+  {{ $target := "" }}
+  {{ if not $scheme }}
+    {{ $link = .url | relLangURL }}
+  {{ else if in (slice "http" "https") $scheme }}
+    {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+  {{ end }}
+  <li class="lh-copy pv2 ba bl-0 bt-0 br-0 b--dotted b--black-20">
+    <a href="{{ $link | safeURL }}" {{ $target | safeHTMLAttr }}>{{ .name }}</a>
+  </li>
+{{ end }}


### PR DESCRIPTION
Currently the URLs in the about page link list in the sidebar are hardcoded to open in a new tab, even if an external link is used. This PR makes the link list URLs context sensitive so that internal links open in the same tab and external links open in a new tab. The implementation uses the same logic as the `shared/btn-links.html` partial.

I've seen at least a few Apero sites using the link list for internal links (including my own), so I think this is a nice add. That way users don't have to override the `about/list.html` layout just to have the link list work in an expected way. And it gives flexibility for users who want a mix of internal and external links in the list.