### PR TITLE
Add toggleable taxonomy links to `sidebar-link` partial

### DIFF
--- a/exampleSite/content/blog/_index.md
+++ b/exampleSite/content/blog/_index.md
@@ -25,6 +25,9 @@ sidebar:
   author: "The R Markdown Team @RStudio"
   text_link_label: Subscribe via RSS
   text_link_url: /index.xml
+  categories_link: true
+  series_link: true
+  tags_link: true
   show_sidebar_adunit: true # show ad container
 
 # set up common front matter for all pages inside blog/

--- a/layouts/partials/shared/sidebar/sidebar-link.html
+++ b/layouts/partials/shared/sidebar/sidebar-link.html
@@ -1,16 +1,16 @@
 {{ if or .text_link_label .categories_link .series_link .tags_link }}
   <div class="dib bt bw1 b--black-10">
     {{ if .text_link_label }}
-      <small class="db f7"><a href="{{ .text_link_url }}" class="dib fw7 ttu pt3">{{ .text_link_label }}</a></small>
+      <small class="db f7 pt3"><a href="{{ .text_link_url }}" class="dib fw7 ttu">{{ .text_link_label }}</a></small>
     {{ end }}
     {{ if .categories_link }}
-      <small class="db f7"><a href="/categories/" class="dib fw7 ttu pt3">Categories</a></small>
+      <small class="db f7 pt3"><a href="/categories/" class="dib fw7 ttu">Categories</a></small>
     {{ end }}
     {{ if .series_link }}
-      <small class="db f7"><a href="/series/" class="dib fw7 ttu pt3">Series</a></small>
+      <small class="db f7 pt3"><a href="/series/" class="dib fw7 ttu">Series</a></small>
     {{ end }}
     {{ if .tags_link }}
-      <small class="db f7"><a href="/tags/" class="dib fw7 ttu pt3">Tags</a></small>
+      <small class="db f7 pt3"><a href="/tags/" class="dib fw7 ttu">Tags</a></small>
     {{ end }}
   </div>
 {{ end }}

--- a/layouts/partials/shared/sidebar/sidebar-link.html
+++ b/layouts/partials/shared/sidebar/sidebar-link.html
@@ -1,1 +1,16 @@
-{{ if .text_link_label }}<small class="db f7"><a href="{{ .text_link_url }}" class="dib fw7 ttu bt bw1 b--black-10 pt3">{{ .text_link_label }}</a></small>{{ end }}
+{{ if or .text_link_label .categories_link .series_link .tags_link }}
+  <div class="dib bt bw1 b--black-10">
+    {{ if .text_link_label }}
+      <small class="db f7"><a href="{{ .text_link_url }}" class="dib fw7 ttu pt3">{{ .text_link_label }}</a></small>
+    {{ end }}
+    {{ if .categories_link }}
+      <small class="db f7"><a href="/categories/" class="dib fw7 ttu pt3">Categories</a></small>
+    {{ end }}
+    {{ if .series_link }}
+      <small class="db f7"><a href="/series/" class="dib fw7 ttu pt3">Series</a></small>
+    {{ end }}
+    {{ if .tags_link }}
+      <small class="db f7"><a href="/tags/" class="dib fw7 ttu pt3">Tags</a></small>
+    {{ end }}
+  </div>
+{{ end }}


### PR DESCRIPTION
This PR adds toggleable taxonomy links (categories, series, and tags) to the `sidebar-link.html` partial. These could be toggled anywhere a text link label can already be used, but the main place it's useful is in the blog list sidebar. It's very basic, but makes it a bit easier for users to explore different content on a site. 

Here are some screenshots:

Showing all links:

![Screen Shot 2021-12-13 at 2 12 19 PM](https://user-images.githubusercontent.com/51542091/145891510-f2e55298-b6bc-416e-8eb8-825aa6df5e57.png)

Hiding the series link:

![Screen Shot 2021-12-13 at 2 12 58 PM](https://user-images.githubusercontent.com/51542091/145891660-a4640430-d946-423a-a94e-29888bc1cb19.png)

Hiding all taxonomy links:

![Screen Shot 2021-12-13 at 2 13 20 PM](https://user-images.githubusercontent.com/51542091/145891716-506086b1-badd-4e1a-be8a-003695637050.png)