### PR TITLE
Make contact form styling match theme

### DIFF
--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -195,7 +195,7 @@ form {
   select,
   [type="text"],
   [type="email"] {
-    @extend .input-reset, .pa3, .mt2, .mb3, .ba, .br0, .b--#{$borderColor}, .bg-transparent, .w-100 ;
+    @extend .input-reset, .pa3, .mt2, .mb3, .ba, .br0, .b--#{$borderColor}, .bg-transparent, .custom-text-color, .w-100;
   }
   [type="button"],
   [type="reset"],
@@ -207,13 +207,13 @@ form {
     @extend .mv2, .mh1 ;
   }
   textarea {
-    @extend .input-reset, .pa3, .mt2, .mb3, .mh0, .lh-copy, .ba, .br0, .b--#{$borderColor}, .bg-transparent, .w-100 ;
+    @extend .input-reset, .pa3, .mt2, .mb3, .mh0, .lh-copy, .ba, .br0, .b--#{$borderColor}, .bg-transparent, .custom-text-color, .w-100;
   }
   select:focus,
   textarea:focus,
   [type="text"]:focus,
   [type="email"]:focus {
-    @extend .bg-white-50 ;
+    @extend .bg-custom-sidebar-bg-color
   }
 }
 


### PR DESCRIPTION
The contact form styling currently looks fine on light coloured themes provided with Apero, but I tried it with a custom dark theme and it didn't look great. The placeholder text remained dark so it was hard to see, and the change of input background colour when focusing being fixed to white wasn't aesthetically pleasing here (the opacity made it an ugly grey).

This PR makes two simple changes:

1. The placeholder text colour is based on the theme's custom text colour, which makes it look good whether the background is light or dark
2. The background colour for the focused form is based on the theme's sidebar colour, which seems to work nicer than having it fixed to white (at least based on the current available themes and a custom dark one I tried) 