### PR TITLE
Add new themes

### DIFF
--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -16,7 +16,7 @@ $font-path: '{{ "fonts" | relURL }}';
 // one of: forest / grayscale / peach / plum / poppy / sky / violet / water 
 // precedence: Params.theme > .Params.custom_colors 
 // custom colors may either be named tachyons color or hex codes
-{{ $themes := (slice "earth" "forest" "grayscale" "magma" "paper" "peach" "plum" "poppy" "sky" "violet" "water") }}
+{{ $themes := (slice "earth" "forest" "grayscale" "magma" "paper" "peach" "plum" "poppy" "primer" "sky" "violet" "water") }}
 {{ if site.Params.theme }}
   {{ if in $themes site.Params.theme }}
     @import '{{ printf "theme/%s" site.Params.theme }}';

--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -16,7 +16,7 @@ $font-path: '{{ "fonts" | relURL }}';
 // one of: forest / grayscale / peach / plum / poppy / sky / violet / water 
 // precedence: Params.theme > .Params.custom_colors 
 // custom colors may either be named tachyons color or hex codes
-{{ $themes := (slice "forest" "grayscale" "peach" "plum" "poppy" "sky" "violet" "water") }}
+{{ $themes := (slice "earth" "forest" "grayscale" "paper" "peach" "plum" "poppy" "sky" "violet" "water") }}
 {{ if site.Params.theme }}
   {{ if in $themes site.Params.theme }}
     @import '{{ printf "theme/%s" site.Params.theme }}';

--- a/assets/scaffold.scss
+++ b/assets/scaffold.scss
@@ -16,7 +16,7 @@ $font-path: '{{ "fonts" | relURL }}';
 // one of: forest / grayscale / peach / plum / poppy / sky / violet / water 
 // precedence: Params.theme > .Params.custom_colors 
 // custom colors may either be named tachyons color or hex codes
-{{ $themes := (slice "earth" "forest" "grayscale" "paper" "peach" "plum" "poppy" "sky" "violet" "water") }}
+{{ $themes := (slice "earth" "forest" "grayscale" "magma" "paper" "peach" "plum" "poppy" "sky" "violet" "water") }}
 {{ if site.Params.theme }}
   {{ if in $themes site.Params.theme }}
     @import '{{ printf "theme/%s" site.Params.theme }}';

--- a/assets/theme/earth.scss
+++ b/assets/theme/earth.scss
@@ -1,0 +1,18 @@
+
+// set your custom colors here
+$siteBgColorCustom: #faf8f6;
+$sidebarBgColorCustom: #f1f1ec;
+$textColorCustom: #17261E;
+$sidebarTextColorCustom: #17261E;
+$headlineColorCustom: #2F4C3E;
+$headingColorCustom: #2b6649;
+$bodyLinkColorCustom: #2b6649;
+$navLinkColorCustom: #2F4C3E;
+$sidebarLinkColorCustom: #2F4C3E;
+$footerTextColorCustom: #666666;
+$buttonTextColorCustom: #faf8f6;
+$buttonHoverTextColorCustom: #faf8f6;
+$buttonBgColorCustom: #2b6649;
+$buttonHoverBgColorCustom: #2F4C3E;
+$borderColorCustom: #666666;
+

--- a/assets/theme/magma.scss
+++ b/assets/theme/magma.scss
@@ -1,0 +1,18 @@
+
+// set your custom colors here
+$siteBgColorCustom: #121212;
+$sidebarBgColorCustom: #2c2c2c;
+$textColorCustom: #ffffff;
+$sidebarTextColorCustom: #ffcc66;
+$headlineColorCustom: #ffcc66;
+$headingColorCustom: #ff9933;
+$bodyLinkColorCustom: #ff9933;
+$navLinkColorCustom: #ff9933;
+$sidebarLinkColorCustom: #ffb44c;
+$footerTextColorCustom: #848484;
+$buttonTextColorCustom: #2c2c2c;
+$buttonHoverTextColorCustom: #2c2c2c;
+$buttonBgColorCustom: #ff9933;
+$buttonHoverBgColorCustom: #ffb44c;
+$borderColorCustom: #424242;
+

--- a/assets/theme/paper.scss
+++ b/assets/theme/paper.scss
@@ -1,0 +1,18 @@
+
+// set your custom colors here
+$siteBgColorCustom: #FFFFFF;
+$sidebarBgColorCustom: #f9f9f9;
+$textColorCustom: #000000;
+$sidebarTextColorCustom: #212121;
+$headlineColorCustom: #000000;
+$headingColorCustom: #000000;
+$bodyLinkColorCustom: #000000;
+$navLinkColorCustom: #000000;
+$sidebarLinkColorCustom: #212121;
+$footerTextColorCustom: #666666;
+$buttonTextColorCustom: #FFFFFF;
+$buttonHoverTextColorCustom: #FFFFFF;
+$buttonBgColorCustom: #212121;
+$buttonHoverBgColorCustom: #000000;
+$borderColorCustom: #666666;
+

--- a/assets/theme/primer.scss
+++ b/assets/theme/primer.scss
@@ -1,0 +1,18 @@
+
+// set your custom colors here
+$siteBgColorCustom: #0d1117;
+$sidebarBgColorCustom: #171c22;
+$textColorCustom: #c9d1d9;
+$sidebarTextColorCustom: #f0f6fc;
+$headlineColorCustom: #8b949e;
+$headingColorCustom: #c9d1d9;
+$bodyLinkColorCustom: #58a6ff;
+$navLinkColorCustom: #ffffff;
+$sidebarLinkColorCustom: #58a6ff;
+$footerTextColorCustom: #8b949e;
+$buttonTextColorCustom: #ffffff;
+$buttonHoverTextColorCustom: #FFFFFF;
+$buttonBgColorCustom: #238636;
+$buttonHoverBgColorCustom: #3fb950;
+$borderColorCustom: #30363d;
+

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -47,7 +47,7 @@ enableEmoji = true
   
   # use a built-in color theme
   # one of: earth / forest / grayscale / magma / paper / peach / plum /
-  #         poppy / sky / violet / water 
+  #         poppy / primer / sky / violet / water 
   theme = "sky"
   
   # or, leave theme empty & make your own palette

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -46,7 +46,7 @@ enableEmoji = true
   twitter = "apreshill"
   
   # use a built-in color theme
-  # one of: earth / forest / grayscale / paper / peach / plum /
+  # one of: earth / forest / grayscale / magma / paper / peach / plum /
   #         poppy / sky / violet / water 
   theme = "sky"
   

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -46,7 +46,7 @@ enableEmoji = true
   twitter = "apreshill"
   
   # use a built-in color theme
-  # one of: forest / grayscale / peach / plum /
+  # one of: earth / forest / grayscale / paper / peach / plum /
   #         poppy / sky / violet / water 
   theme = "sky"
   


### PR DESCRIPTION
Four new themes!

## earth

"earth" is like an inverted version of the forest theme (similar to how "sky" is an inversion of "water" or "plum" an inversion of "violet").

![Screen Shot 2022-01-20 at 10 53 51 AM](https://user-images.githubusercontent.com/51542091/150394816-5b0e358b-e2bd-4245-b0c2-6f5ed6d0c79a.png)

## paper

"paper" is a purely black and white theme. There's obviously overlap with the "grayscale" theme, but I think this still has its own appeal with its starker contrast.

![Screen Shot 2022-01-20 at 10 54 12 AM](https://user-images.githubusercontent.com/51542091/150394884-61479146-7538-4aa4-b46d-19d21ce806f6.png)

## magma

"magma" is a dark theme inspired by the LCARS computers from Star Trek, which I also have a custom code chunk highlighting theme to go along with if we ever add that to Apero. Doubles as a Halloween theme... 👻 

![Screen Shot 2022-01-20 at 10 54 40 AM](https://user-images.githubusercontent.com/51542091/150394934-05a3df54-7b8f-4f8f-bbd4-687de4dc0e11.png)

## primer

"primer" is a dark theme that uses the colour scheme from GitHub's dark primer theme.

![Screen Shot 2022-01-20 at 10 55 00 AM](https://user-images.githubusercontent.com/51542091/150394967-59c81238-12f3-4cb5-b84f-da938be727dd.png)

## Asides based on my experience making these

- It might be nice to add documentation on how to contribute new themes, if that's something we're interested in. It's easy but we could make it easier 😄 
- Some more options on the colours of specific elements in the theme might be nice. For example, having footer and icon link colours be their own thing rather than tying them into the `$navLinkColorCustom` option. So adding: `$footerLinkColorCustom` and `$iconLinkColorCustom` as options.