### PR TITLE
Replace deprecated `.Page.UniqueID` variable

### DIFF
--- a/layouts/partials/shared/breadcrumb.html
+++ b/layouts/partials/shared/breadcrumb.html
@@ -1,17 +1,17 @@
 <h4 class="breadcrumb pb5">
-{{ template "breadcrumb" dict "currentPage" .Page "id" .UniqueID }}
+{{ template "breadcrumb" dict "currentPage" .Page "id" .File.UniqueID }}
 </h4>
 
 <!-- templates -->
 {{ define "breadcrumb" }}
- {{ if .currentPage.Parent }}
- {{ if ne .currentPage.Parent .IsHome }}
-    {{ template "breadcrumb" dict "currentPage" .currentPage.Parent }}
-  {{ end }}
-    {{ if eq .id .currentPage.UniqueID }}
+  {{ if .currentPage.Parent }}
+    {{ if ne .currentPage.Parent .IsHome }}
+      {{ template "breadcrumb" dict "currentPage" .currentPage.Parent }}
+    {{ end }}
+    {{ if eq .id .currentPage.File.UniqueID }}
       {{ .currentPage.Title }}
     {{ else }}
-      <a href="{{ .currentPage.RelPermalink }}">{{ .currentPage.Title }}</a> >
+      <a href="{{ .currentPage.RelPermalink }}">{{ .currentPage.Title }}</a>
     {{ end }}
-{{ end }}
+  {{ end }}
 {{ end }}


### PR DESCRIPTION
Fix #76.

As stated in https://github.com/hugo-apero/hugo-apero/issues/76#issuecomment-1059045295, the syntax of getting ID of a page changes from `Page.UniqueID` to `Page.File.UniqueID` after Hugo v0.69 (https://github.com/gohugoio/hugo/commit/89044b8f8795f17c36396c67823183a20fc88139).