### PR TITLE
Display home page image at top of page at smaller screen widths

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,18 +2,18 @@
 {{ $page := . }}
 <main class="page-main pa4" role="main">
   <section class="page-content mw9 center">
-    <div class="flex-l items-center" style="{{ if .Params.image_left }}flex-direction: row-reverse;{{ end }}">
+    <div class="flex-l items-center" style="{{ if not .Params.image_left }}flex-direction: row-reverse;{{ end }}">
+      <div class="tr w-50-l {{ if .Params.image_left }}ml4{{ else }}mr4{{ end }}">
+      {{ with .Params.images }}
+        {{ range first 1 . }}<img class="mv0 w-70-m" src="{{ . }}"/>{{ end }}
+      {{ end }}
+      </div>
       <div class="mh4 w-50-l {{ if not .Params.text_align_left }}tr{{ end }}">
         {{ with .Params.title }}<h1 class="f2 f1-m f-subheadline-l fw5-ns mv4 lh-solid">{{ . }}</h1>{{ end }}
         {{ with .Params.subtitle }}<h2 class="f5 fw7 mt0 mb4 ttu tracked">{{ . }}</h2>{{ end }}
         {{ if .Params.show_social_links }}{{ partial "shared/social-links.html" . }}{{ end }}
         {{ with .Params.description }}<p class="f4 mt4 lh-copy">{{ . | markdownify }}</p>{{ end }}
         {{ if .Params.show_action_link }}<a class="mt4 action {{ .Params.action_type }}" href="{{ .Params.action_link | relURL }}">{{ .Params.action_label | safeHTML }}</a>{{ end }}
-      </div>
-      <div class="tr w-50-l {{ if .Params.image_left }}ml4{{ else }}mr4{{ end }}">
-      {{ with .Params.images }}
-        {{ range first 1 . }}<img class="mv0 w-70-m" src="{{ . }}"/>{{ end }}
-      {{ end }}
       </div>
     </div>
   </section>


### PR DESCRIPTION
Currently, the image selected for the home page moves to the bottom of the page when viewed in windows with smaller screen widths (e.g., on a smartphone), as seen below.

<p align="center">
<img width="208" alt="screenshot of Apero example site home page viewed at small screen width, showing site image at bottom" src="https://user-images.githubusercontent.com/66031887/187553814-7d9a6f48-ce37-4924-a57a-5e28e40845c7.png">
<p>

This PR modifies the theme layout so that the home page image is displayed at the top at smaller screen widths, as seen below.

<p align="center">
<img width="208" alt="screenshot of Apero example site home page with modified code viewed at small screen width, showing site image at top" src="https://user-images.githubusercontent.com/66031887/187554071-801b8319-f2d9-4161-b996-cfadbee1c5ca.png">
<p>

This modification works when the image_left parameter is set to either true or false and does not modify the home page appearance at non-narrow screen widths.

For personal websites, where users often display images of themselves on the home page, having the image wrap to the top makes visual sense and is consistent with the default behavior of many other Hugo personal website themes. Of course, this placement of the home page image is partly a matter of taste and so may not warrant being the default behavior.