### PR TITLE
Add the rel="me" attribute to social media links

### DIFF
--- a/layouts/partials/shared/social-links.html
+++ b/layouts/partials/shared/social-links.html
@@ -12,7 +12,7 @@
     {{ if not $scheme }}
       {{ $link = .url | relLangURL }}
     {{ else if in (slice "http" "https") $scheme }}
-      {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+      {{ $target = "target=\"_blank\" rel=\"me noopener\"" }}
     {{ end }}
     <a class="link dib h1 w1 ml0 mr2 f6 o-90 glow" href="{{ $link | safeURL }}" title="{{ .icon }}" {{ $target | safeHTMLAttr }}>
       <i class="{{ $pack }} {{ $pack_prefix }}-{{ .icon }} fa-lg fa-fw"></i>


### PR DESCRIPTION
This PR adds a `rel="me"` attributes to social media links. 

This attribute enables a way for people to identify themselves to a web service thanks to their website using the [XHTML Friends Network (XFN) specification](https://gmpg.org/xfn/). More info [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/me).

Mastodon, which recently gained in popularity, uses this method to verify that a page belongs to a Mastodon account. When a webpage contains a link to a mastodon account with this attributes, it automatically shows a verification mark on a user's Mastodon webpage. More info on mastodon's [doc](https://docs.joinmastodon.org/user/profile/#fields). 

<img width="735" alt="This screenshot shows a green tick next to a verified webpage for a Mastodon account" src="https://user-images.githubusercontent.com/13061584/201094413-7db762f3-d5a0-40c5-a201-fe2ba2ebf76c.png">

Setting up this attributes for the social media links should improve safety for Mastodon users who adopted the Apero theme.