### PR TITLE
Restore angle bracket used for breadcrumb arrow

### DIFF
--- a/layouts/partials/shared/breadcrumb.html
+++ b/layouts/partials/shared/breadcrumb.html
@@ -12,6 +12,7 @@
       {{ .currentPage.Title }}
     {{ else }}
       <a href="{{ .currentPage.RelPermalink }}">{{ .currentPage.Title }}</a>
+      <!-- The following bracket is intentional! It's a breadcrumb arrow. --> >
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
In #78 the angle bracket used for the breadcrumb arrow was removed by accident. See the end of line 14 [here](https://github.com/hugo-apero/hugo-apero/pull/78/commits/01ea0b95e6510ccb34cbd9c399d67cb921d64ccd#diff-94688f50fabd8c05711e3e09be299688d0e13b1ca3c920d1318e54f3fbef498fL14).

This PR restores said angle bracket and leaves a comment so it's more obvious it was intentional.